### PR TITLE
Fix a script inclusion bug in vector example

### DIFF
--- a/docs/examples/ctrl-vector.html
+++ b/docs/examples/ctrl-vector.html
@@ -26,5 +26,5 @@ const obj = {
 }
 function callbk() { document.getElementById('out').innerHTML = "var obj = "+Ctrling.stringify(obj); }
 </script>
-<script src="../../ctrling.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ctrling/ctrling.min.js"></script>
 </html>


### PR DESCRIPTION
The vector example wasn't loading because the ctrling script was included locally instead of including it from the cdn source. As all other demos where including the script from the cdn I made the change accordingly and the demo is now fixed.